### PR TITLE
Add workaround on exit status not returning

### DIFF
--- a/free_resource.c
+++ b/free_resource.c
@@ -20,7 +20,7 @@ void free_res(char **lineptr, size_t *n)
  */
 int to_int(char *str)
 {
-	int i = 0, j = 0, num = 0, temp, times, power_of, str_len = _strlen(str) - 1;
+	int i = 0, j = 0, num = 0, temp, times, power_of, str_len = _strlen(str);
 
 	while (j < str_len)
 	{

--- a/shell.c
+++ b/shell.c
@@ -9,7 +9,7 @@
 int main(int ac, char **av, char **env)
 {
 	char *prog_n = av[ac - 1];
-	int status;
+	int status, code;
 	char *lineptr = NULL;
 	pid_t ps;
 
@@ -33,7 +33,10 @@ int main(int ac, char **av, char **env)
 			if (!(isatty(STDIN_FILENO)))
 				break;
 			else if (WEXITSTATUS(status) > 0)
-				break;
+			{
+				code = WEXITSTATUS(status);
+				exit(code);
+			}
 		}
 	}
 	return (0);


### PR DESCRIPTION
add workaround on exit an non-returning exit status code